### PR TITLE
Added a setting to toggle connecting bones on import.

### DIFF
--- a/3.6.8/io_scene_fbx_patch_ahit/__init__.py
+++ b/3.6.8/io_scene_fbx_patch_ahit/__init__.py
@@ -49,6 +49,8 @@ from bpy_extras.io_utils import (
 DEF_IMPORT_ROOT_AS_BONE = True
 # For vanilla behaviour, change this one to False
 DEF_IMPORT_SCALE_INHERITANCE = True
+# For vanilla behaviour, change this one to True
+DEF_IMPORT_CONNECT_CHILDREN = False
 # For vanilla behaviour, change this one to 'ALWAYS'
 DEF_IMPORT_FPS_RULE = 'IF_FOUND'
 # For vanilla behaviour, change this one to False
@@ -215,6 +217,15 @@ class ImportFBX(bpy.types.Operator, ImportHelper):
             name="UE3 - Import Scale Inheritance",
             description="If enabled, the per-bone Inherit Scale property is correctly imported (AHiT always uses 'Aligned')",
             default=DEF_IMPORT_SCALE_INHERITANCE,
+            )
+    # UnDrew Add End
+    # UnDrew Add Start : Option to toggle whether to try connecting bones on import.
+    UE3_connect_children: BoolProperty(
+            name="UE3 - Connect Children",
+            description="If disabled, don't attempt to connect bones at all. "
+                        "If enabled (vanilla), connect child bones if their position matches the parent's tail "
+                        "(Note this can break translation animation sometimes)",
+            default=DEF_IMPORT_CONNECT_CHILDREN,
             )
     # UnDrew Add End
     force_connect_children: BoolProperty(
@@ -443,6 +454,9 @@ class FBX_PT_import_armature_ahit_patch(bpy.types.Panel):
         operator = sfile.active_operator
 
         layout.prop(operator, "ignore_leaf_bones")
+        # UnDrew Add Start : Option to toggle whether to try connecting bones on import.
+        layout.prop(operator, "UE3_connect_children")
+        # UnDrew Add End
         layout.prop(operator, "force_connect_children"),
         layout.prop(operator, "automatic_bone_orientation"),
         sub = layout.column()

--- a/3.6.8/io_scene_fbx_patch_ahit/fbx_utils.py
+++ b/3.6.8/io_scene_fbx_patch_ahit/fbx_utils.py
@@ -1727,7 +1727,7 @@ FBXImportSettings = namedtuple("FBXImportSettings", (
     "nodal_material_wrap_map", "image_cache",
     "ignore_leaf_bones", "force_connect_children", "automatic_bone_orientation", "bone_correction_matrix",
     # UnDrew Add Start : New settings that need to be passed to the importer's "settings" var.
-    "UE3_import_root_as_bone", "UE3_import_scale_inheritance",
+    "UE3_import_root_as_bone", "UE3_import_scale_inheritance", "UE3_connect_children",
     # UnDrew Add End
     "use_prepost_rot", "colors_type",
 ))

--- a/3.6.8/io_scene_fbx_patch_ahit/import_fbx.py
+++ b/3.6.8/io_scene_fbx_patch_ahit/import_fbx.py
@@ -2251,6 +2251,11 @@ class FbxImportHelperNode:
                 child_bone.parent = par_bone
                 child_head = child_bone.head
 
+            # UnDrew Add Start : Don't do any of this if the custom setting is disabled.
+            if not settings.UE3_connect_children:
+                return
+            # UnDrew Add End
+
             if similar_values_iter(par_bone.tail, child_head):
                 if child_bone is not None:
                     child_bone.use_connect = True
@@ -2271,6 +2276,11 @@ class FbxImportHelperNode:
             connect_ctx[1] = connected
 
         def child_connect_finalize(par_bone, connect_ctx):
+            # UnDrew Add Start : Don't do any of this if the custom setting is disabled.
+            if not settings.UE3_connect_children:
+                return
+            # UnDrew Add End
+
             force_connect_children, connected = connect_ctx
             # Do nothing if force connection is not enabled!
             if force_connect_children and connected is not None and connected is not ...:
@@ -2673,6 +2683,7 @@ def load(operator, context, filepath="",
          UE3_import_scale_inheritance=True,
          UE3_fps_import_rule='IF_FOUND',   # doesn't need to be passed in the settings tuple, it's only used here.
          UE3_custom_fps_fix=True,   # ...neither does this.
+         UE3_connect_children=False,
          # UnDrew Add End
          force_connect_children=False,
          automatic_bone_orientation=False,
@@ -2829,7 +2840,7 @@ def load(operator, context, filepath="",
         nodal_material_wrap_map, image_cache,
         ignore_leaf_bones, force_connect_children, automatic_bone_orientation, bone_correction_matrix,
         # UnDrew Add Start : New import settings.
-        UE3_import_root_as_bone, UE3_import_scale_inheritance,
+        UE3_import_root_as_bone, UE3_import_scale_inheritance, UE3_connect_children,
         # UnDrew Add End
         use_prepost_rot, colors_type,
     )

--- a/4.2.0/io_scene_fbx_patch_ahit/__init__.py
+++ b/4.2.0/io_scene_fbx_patch_ahit/__init__.py
@@ -52,6 +52,8 @@ from bpy_extras.io_utils import (
 DEF_IMPORT_ROOT_AS_BONE = True
 # For vanilla behaviour, change this one to False
 DEF_IMPORT_SCALE_INHERITANCE = True
+# For vanilla behaviour, change this one to True
+DEF_IMPORT_CONNECT_CHILDREN = False
 # For vanilla behaviour, change this one to 'ALWAYS'
 DEF_IMPORT_FPS_RULE = 'IF_FOUND'
 # For vanilla behaviour, change this one to False
@@ -220,6 +222,15 @@ class ImportFBX(bpy.types.Operator, ImportHelper):
         default=DEF_IMPORT_SCALE_INHERITANCE,
     )
     # UnDrew Add End
+    # UnDrew Add Start : Option to toggle whether to try connecting bones on import.
+    UE3_connect_children: BoolProperty(
+        name="UE3 - Connect Children",
+        description="If disabled, don't attempt to connect bones at all. "
+                    "If enabled (vanilla), connect child bones if their position matches the parent's tail "
+                    "(Note this can break translation animation sometimes)",
+        default=DEF_IMPORT_CONNECT_CHILDREN,
+    )
+    # UnDrew Add End
     force_connect_children: BoolProperty(
         name="Force Connect Children",
         description="Force connection of children bones to their parent, even if their computed head/tail "
@@ -351,6 +362,9 @@ def import_panel_armature(layout, operator):
     header.label(text="Armature")
     if body:
         body.prop(operator, "ignore_leaf_bones")
+        # UnDrew Add Start : Option to toggle whether to try connecting bones on import.
+        body.prop(operator, "UE3_connect_children")
+        # UnDrew Add End
         body.prop(operator, "force_connect_children"),
         body.prop(operator, "automatic_bone_orientation"),
         sub = body.column()

--- a/4.2.0/io_scene_fbx_patch_ahit/fbx_utils.py
+++ b/4.2.0/io_scene_fbx_patch_ahit/fbx_utils.py
@@ -2077,7 +2077,7 @@ FBXImportSettings = namedtuple("FBXImportSettings", (
     "nodal_material_wrap_map", "image_cache",
     "ignore_leaf_bones", "force_connect_children", "automatic_bone_orientation", "bone_correction_matrix",
     # UnDrew Add Start : New settings that need to be passed to the importer's "settings" var.
-    "UE3_import_root_as_bone", "UE3_import_scale_inheritance",
+    "UE3_import_root_as_bone", "UE3_import_scale_inheritance", "UE3_connect_children",
     # UnDrew Add End
     "use_prepost_rot", "colors_type",
 ))

--- a/4.2.0/io_scene_fbx_patch_ahit/import_fbx.py
+++ b/4.2.0/io_scene_fbx_patch_ahit/import_fbx.py
@@ -2649,6 +2649,11 @@ class FbxImportHelperNode:
                 child_bone.parent = par_bone
                 child_head = child_bone.head
 
+            # UnDrew Add Start : Don't do any of this if the custom setting is disabled.
+            if not settings.UE3_connect_children:
+                return
+            # UnDrew Add End
+
             if similar_values_iter(par_bone.tail, child_head):
                 if child_bone is not None:
                     child_bone.use_connect = True
@@ -2669,6 +2674,11 @@ class FbxImportHelperNode:
             connect_ctx[1] = connected
 
         def child_connect_finalize(par_bone, connect_ctx):
+            # UnDrew Add Start : Don't do any of this if the custom setting is disabled.
+            if not settings.UE3_connect_children:
+                return
+            # UnDrew Add End
+
             force_connect_children, connected = connect_ctx
             # Do nothing if force connection is not enabled!
             if force_connect_children and connected is not None and connected is not ...:
@@ -3091,6 +3101,7 @@ def load(operator, context, filepath="",
          UE3_import_scale_inheritance=True,
          UE3_fps_import_rule='IF_FOUND',   # doesn't need to be passed in the settings tuple, it's only used here.
          UE3_custom_fps_fix=True,   # ...neither does this.
+         UE3_connect_children=False,
          # UnDrew Add End
          force_connect_children=False,
          automatic_bone_orientation=False,
@@ -3247,7 +3258,7 @@ def load(operator, context, filepath="",
         nodal_material_wrap_map, image_cache,
         ignore_leaf_bones, force_connect_children, automatic_bone_orientation, bone_correction_matrix,
         # UnDrew Add Start : New import settings.
-        UE3_import_root_as_bone, UE3_import_scale_inheritance,
+        UE3_import_root_as_bone, UE3_import_scale_inheritance, UE3_connect_children,
         # UnDrew Add End
         use_prepost_rot, colors_type,
     )

--- a/4.3.0/io_scene_fbx_patch_ahit/__init__.py
+++ b/4.3.0/io_scene_fbx_patch_ahit/__init__.py
@@ -52,6 +52,8 @@ from bpy_extras.io_utils import (
 DEF_IMPORT_ROOT_AS_BONE = True
 # For vanilla behaviour, change this one to False
 DEF_IMPORT_SCALE_INHERITANCE = True
+# For vanilla behaviour, change this one to True
+DEF_IMPORT_CONNECT_CHILDREN = False
 # For vanilla behaviour, change this one to 'ALWAYS'
 DEF_IMPORT_FPS_RULE = 'IF_FOUND'
 # For vanilla behaviour, change this one to False
@@ -220,6 +222,15 @@ class ImportFBX(bpy.types.Operator, ImportHelper):
         default=DEF_IMPORT_SCALE_INHERITANCE,
     )
     # UnDrew Add End
+    # UnDrew Add Start : Option to toggle whether to try connecting bones on import.
+    UE3_connect_children: BoolProperty(
+        name="UE3 - Connect Children",
+        description="If disabled, don't attempt to connect bones at all. "
+                    "If enabled (vanilla), connect child bones if their position matches the parent's tail "
+                    "(Note this can break translation animation sometimes)",
+        default=DEF_IMPORT_CONNECT_CHILDREN,
+    )
+    # UnDrew Add End
     force_connect_children: BoolProperty(
         name="Force Connect Children",
         description="Force connection of children bones to their parent, even if their computed head/tail "
@@ -351,6 +362,9 @@ def import_panel_armature(layout, operator):
     header.label(text="Armature")
     if body:
         body.prop(operator, "ignore_leaf_bones")
+        # UnDrew Add Start : Option to toggle whether to try connecting bones on import.
+        body.prop(operator, "UE3_connect_children")
+        # UnDrew Add End
         body.prop(operator, "force_connect_children"),
         body.prop(operator, "automatic_bone_orientation"),
         sub = body.column()

--- a/4.3.0/io_scene_fbx_patch_ahit/fbx_utils.py
+++ b/4.3.0/io_scene_fbx_patch_ahit/fbx_utils.py
@@ -2077,7 +2077,7 @@ FBXImportSettings = namedtuple("FBXImportSettings", (
     "nodal_material_wrap_map", "image_cache",
     "ignore_leaf_bones", "force_connect_children", "automatic_bone_orientation", "bone_correction_matrix",
     # UnDrew Add Start : New settings that need to be passed to the importer's "settings" var.
-    "UE3_import_root_as_bone", "UE3_import_scale_inheritance",
+    "UE3_import_root_as_bone", "UE3_import_scale_inheritance", "UE3_connect_children",
     # UnDrew Add End
     "use_prepost_rot", "colors_type",
 ))

--- a/4.3.0/io_scene_fbx_patch_ahit/import_fbx.py
+++ b/4.3.0/io_scene_fbx_patch_ahit/import_fbx.py
@@ -2640,6 +2640,11 @@ class FbxImportHelperNode:
                 child_bone.parent = par_bone
                 child_head = child_bone.head
 
+            # UnDrew Add Start : Don't do any of this if the custom setting is disabled.
+            if not settings.UE3_connect_children:
+                return
+            # UnDrew Add End
+
             if similar_values_iter(par_bone.tail, child_head):
                 if child_bone is not None:
                     child_bone.use_connect = True
@@ -2660,6 +2665,11 @@ class FbxImportHelperNode:
             connect_ctx[1] = connected
 
         def child_connect_finalize(par_bone, connect_ctx):
+            # UnDrew Add Start : Don't do any of this if the custom setting is disabled.
+            if not settings.UE3_connect_children:
+                return
+            # UnDrew Add End
+
             force_connect_children, connected = connect_ctx
             # Do nothing if force connection is not enabled!
             if force_connect_children and connected is not None and connected is not ...:
@@ -3082,6 +3092,7 @@ def load(operator, context, filepath="",
          UE3_import_scale_inheritance=True,
          UE3_fps_import_rule='IF_FOUND',   # doesn't need to be passed in the settings tuple, it's only used here.
          UE3_custom_fps_fix=True,   # ...neither does this.
+         UE3_connect_children=False,
          # UnDrew Add End
          force_connect_children=False,
          automatic_bone_orientation=False,
@@ -3238,7 +3249,7 @@ def load(operator, context, filepath="",
         nodal_material_wrap_map, image_cache,
         ignore_leaf_bones, force_connect_children, automatic_bone_orientation, bone_correction_matrix,
         # UnDrew Add Start : New import settings.
-        UE3_import_root_as_bone, UE3_import_scale_inheritance,
+        UE3_import_root_as_bone, UE3_import_scale_inheritance, UE3_connect_children,
         # UnDrew Add End
         use_prepost_rot, colors_type,
     )


### PR DESCRIPTION
In vanilla, the addon marks a child bone as Connected if its position matches the parent's tail. This, however, also prevents that bone from translating.

It's very unlikely UE3-exported models will be influenced by this, but blender-exported models definitely can be. And Blender's importer and exporter being incompatible with each other is baffling.

Therefore, a new setting was added to toggle this behavior off. It is also changed by default, since it provides more consistent results (and far less likely to confuse someone if they aren't aware of this quirk).