### PR TITLE
Added a setting for initializing the id_root of imported actions

### DIFF
--- a/3.6.8/io_scene_fbx_patch_ahit/__init__.py
+++ b/3.6.8/io_scene_fbx_patch_ahit/__init__.py
@@ -55,6 +55,8 @@ DEF_IMPORT_CONNECT_CHILDREN = False
 DEF_IMPORT_FPS_RULE = 'IF_FOUND'
 # For vanilla behaviour, change this one to False
 DEF_IMPORT_CUSTOM_FPS_FIX = True
+# For vanilla behaviour, change this one to False
+DEF_IMPORT_ACTION_DOMAIN = True
 
 # For vanilla behaviour, change this one to False
 DEF_EXPORT_DONT_ADD_ARMATURE_BONE = True
@@ -180,6 +182,14 @@ class ImportFBX(bpy.types.Operator, ImportHelper):
             name="UE3 - Custom FPS fix",
             description="Fixes an oversight where the Base part of a custom frame rate would get ignored when importing animations",
             default=DEF_IMPORT_CUSTOM_FPS_FIX,
+            )
+    # UnDrew Add End
+    # UnDrew Add Start : Fix for actions being created without initializing their id_root.
+    UE3_set_action_id_root: BoolProperty(
+            name="UE3 - Set action domains",
+            description="Automatically makes imported actions only appear on the relevant Object/ID types. "
+                        "Useful to avoid accidently locking an action to the wrong type later down the line",
+            default=DEF_IMPORT_ACTION_DOMAIN,
             )
     # UnDrew Add End
 
@@ -426,6 +436,9 @@ class FBX_PT_import_animation_ahit_patch(bpy.types.Panel):
         # UnDrew Add End
         # UnDrew Add Start : Time dilation fix when using Custom FPS.
         layout.prop(operator, "UE3_custom_fps_fix")
+        # UnDrew Add End
+        # UnDrew Add Start : Fix for actions being created without initializing their id_root.
+        layout.prop(operator, "UE3_set_action_id_root")
         # UnDrew Add End
 
 

--- a/4.2.0/io_scene_fbx_patch_ahit/__init__.py
+++ b/4.2.0/io_scene_fbx_patch_ahit/__init__.py
@@ -58,6 +58,8 @@ DEF_IMPORT_CONNECT_CHILDREN = False
 DEF_IMPORT_FPS_RULE = 'IF_FOUND'
 # For vanilla behaviour, change this one to False
 DEF_IMPORT_CUSTOM_FPS_FIX = True
+# For vanilla behaviour, change this one to False
+DEF_IMPORT_ACTION_DOMAIN = True
 
 # For vanilla behaviour, change this one to False
 DEF_EXPORT_DONT_ADD_ARMATURE_BONE = True
@@ -183,6 +185,14 @@ class ImportFBX(bpy.types.Operator, ImportHelper):
         name="UE3 - Custom FPS fix",
         description="Fixes an oversight where the Base part of a custom frame rate would get ignored when importing animations",
         default=DEF_IMPORT_CUSTOM_FPS_FIX,
+    )
+    # UnDrew Add End
+    # UnDrew Add Start : Fix for actions being created without initializing their id_root.
+    UE3_set_action_id_root: BoolProperty(
+        name="UE3 - Set action domains",
+        description="Automatically makes imported actions only appear on the relevant Object/ID types. "
+                    "Useful to avoid accidently locking an action to the wrong type later down the line",
+        default=DEF_IMPORT_ACTION_DOMAIN,
     )
     # UnDrew Add End
 
@@ -354,6 +364,9 @@ def import_panel_animation(layout, operator):
         # UnDrew Add End
         # UnDrew Add Start : Time dilation fix when using Custom FPS.
         body.prop(operator, "UE3_custom_fps_fix")
+        # UnDrew Add End
+        # UnDrew Add Start : Fix for actions being created without initializing their id_root.
+        body.prop(operator, "UE3_set_action_id_root")
         # UnDrew Add End
 
 

--- a/4.2.0/io_scene_fbx_patch_ahit/import_fbx.py
+++ b/4.2.0/io_scene_fbx_patch_ahit/import_fbx.py
@@ -1070,7 +1070,7 @@ def blen_read_animations_action_item(action, item, cnodes, fps, anim_offset, glo
 
 
 # UnDrew Edit Start : Pass the FPS fix setting.
-def blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, anim_offset, UE3_custom_fps_fix, global_scale, fbx_ktime):
+def blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, anim_offset, UE3_custom_fps_fix, UE3_set_action_id_root, global_scale, fbx_ktime):
 # UnDrew Edit End
     """
     Recreate an action per stack/layer/object combinations.
@@ -1111,6 +1111,10 @@ def blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, anim_o
                         action_name = "|".join((id_data.name, stack_name, layer_name))
                     actions[key] = action = bpy.data.actions.new(action_name)
                     action.use_fake_user = True
+                    # UnDrew Add Start : Set the proper id_root on the action, so it isn't possible to irreparably lock an action to the wrong type.
+                    if UE3_set_action_id_root:
+                        action.id_root = id_data.id_type
+                    # UnDrew Add End
                 # If none yet assigned, assign this action to id_data.
                 if not id_data.animation_data:
                     id_data.animation_data_create()
@@ -3101,6 +3105,7 @@ def load(operator, context, filepath="",
          UE3_import_scale_inheritance=True,
          UE3_fps_import_rule='IF_FOUND',   # doesn't need to be passed in the settings tuple, it's only used here.
          UE3_custom_fps_fix=True,   # ...neither does this.
+         UE3_set_action_id_root=True,   # ...neither does this.
          UE3_connect_children=False,
          # UnDrew Add End
          force_connect_children=False,
@@ -3900,8 +3905,8 @@ def load(operator, context, filepath="",
                     curvenodes[acn_uuid][ac_uuid] = (fbx_acitem, channel)
 
             # And now that we have sorted all this, apply animations!
-            # UnDrew Edit Start : Pass the FPS fix setting.
-            blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, settings.anim_offset, UE3_custom_fps_fix, global_scale,
+            # UnDrew Edit Start : Pass settings.
+            blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, settings.anim_offset, UE3_custom_fps_fix, UE3_set_action_id_root, global_scale,
                                  fbx_ktime)
             # UnDrew Edit End
 

--- a/4.3.0/io_scene_fbx_patch_ahit/__init__.py
+++ b/4.3.0/io_scene_fbx_patch_ahit/__init__.py
@@ -58,6 +58,8 @@ DEF_IMPORT_CONNECT_CHILDREN = False
 DEF_IMPORT_FPS_RULE = 'IF_FOUND'
 # For vanilla behaviour, change this one to False
 DEF_IMPORT_CUSTOM_FPS_FIX = True
+# For vanilla behaviour, change this one to False
+DEF_IMPORT_ACTION_DOMAIN = True
 
 # For vanilla behaviour, change this one to False
 DEF_EXPORT_DONT_ADD_ARMATURE_BONE = True
@@ -183,6 +185,14 @@ class ImportFBX(bpy.types.Operator, ImportHelper):
         name="UE3 - Custom FPS fix",
         description="Fixes an oversight where the Base part of a custom frame rate would get ignored when importing animations",
         default=DEF_IMPORT_CUSTOM_FPS_FIX,
+    )
+    # UnDrew Add End
+    # UnDrew Add Start : Fix for actions being created without initializing their id_root.
+    UE3_set_action_id_root: BoolProperty(
+        name="UE3 - Set action domains",
+        description="Automatically makes imported actions only appear on the relevant Object/ID types. "
+                    "Useful to avoid accidently locking an action to the wrong type later down the line",
+        default=DEF_IMPORT_ACTION_DOMAIN,
     )
     # UnDrew Add End
 
@@ -354,6 +364,9 @@ def import_panel_animation(layout, operator):
         # UnDrew Add End
         # UnDrew Add Start : Time dilation fix when using Custom FPS.
         body.prop(operator, "UE3_custom_fps_fix")
+        # UnDrew Add End
+        # UnDrew Add Start : Fix for actions being created without initializing their id_root.
+        body.prop(operator, "UE3_set_action_id_root")
         # UnDrew Add End
 
 

--- a/4.3.0/io_scene_fbx_patch_ahit/import_fbx.py
+++ b/4.3.0/io_scene_fbx_patch_ahit/import_fbx.py
@@ -1070,7 +1070,7 @@ def blen_read_animations_action_item(action, item, cnodes, fps, anim_offset, glo
 
 
 # UnDrew Edit Start : Pass the FPS fix setting.
-def blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, anim_offset, UE3_custom_fps_fix, global_scale, fbx_ktime):
+def blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, anim_offset, UE3_custom_fps_fix, UE3_set_action_id_root, global_scale, fbx_ktime):
 # UnDrew Edit End
     """
     Recreate an action per stack/layer/object combinations.
@@ -1111,6 +1111,10 @@ def blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, anim_o
                         action_name = "|".join((id_data.name, stack_name, layer_name))
                     actions[key] = action = bpy.data.actions.new(action_name)
                     action.use_fake_user = True
+                    # UnDrew Add Start : Set the proper id_root on the action, so it isn't possible to irreparably lock an action to the wrong type.
+                    if UE3_set_action_id_root:
+                        action.id_root = id_data.id_type
+                    # UnDrew Add End
                 # If none yet assigned, assign this action to id_data.
                 if not id_data.animation_data:
                     id_data.animation_data_create()
@@ -3092,6 +3096,7 @@ def load(operator, context, filepath="",
          UE3_import_scale_inheritance=True,
          UE3_fps_import_rule='IF_FOUND',   # doesn't need to be passed in the settings tuple, it's only used here.
          UE3_custom_fps_fix=True,   # ...neither does this.
+         UE3_set_action_id_root=True,   # ...neither does this.
          UE3_connect_children=False,
          # UnDrew Add End
          force_connect_children=False,
@@ -3891,8 +3896,8 @@ def load(operator, context, filepath="",
                     curvenodes[acn_uuid][ac_uuid] = (fbx_acitem, channel)
 
             # And now that we have sorted all this, apply animations!
-            # UnDrew Edit Start : Pass the FPS fix setting.
-            blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, settings.anim_offset, UE3_custom_fps_fix, global_scale,
+            # UnDrew Edit Start : Pass settings.
+            blen_read_animations(fbx_tmpl_astack, fbx_tmpl_alayer, stacks, scene, settings.anim_offset, UE3_custom_fps_fix, UE3_set_action_id_root, global_scale,
                                  fbx_ktime)
             # UnDrew Edit End
 


### PR DESCRIPTION
The id_root property is what determines what type of ID the action belongs to (e.g. An object animation has id_root='OBJECT', a shape key animation has id_root='KEY').

In vanilla, the addon doesn't initialize this property, so id_root remains unspecified until it's assigned to an ID/object. When that happens, blender automatically locks that action to that specific type. This is problematic, as the user could accidentally lock an action to the wrong type, rendering it unusable.

This setting (enabled by default), initializes actions to the target ID type to avoid that issue.