### PR TITLE
New export setting: UE3 - Export Scale Inheritance

### DIFF
--- a/io_scene_fbx_patch_ahit/__init__.py
+++ b/io_scene_fbx_patch_ahit/__init__.py
@@ -273,6 +273,8 @@ DEF_IMPORT_ACTION_DOMAIN = True
 # For vanilla behaviour, change this one to False
 DEF_EXPORT_DONT_ADD_ARMATURE_BONE = True
 # For vanilla behaviour, change this one to False
+DEF_EXPORT_SCALE_INHERITANCE = True
+# For vanilla behaviour, change this one to False
 DEF_EXPORT_FORCE_ALIGNED_SCALING = True
 # For vanilla behaviour, change this one to False
 DEF_EXPORT_MATRIX_DOUBLE_PRECISION = False
@@ -814,6 +816,14 @@ class ExportFBX_patch_ahit(bpy.types.Operator, ExportHelper):
         default=DEF_EXPORT_DONT_ADD_ARMATURE_BONE,
     )
     # UnDrew Add End
+    # UnDrew Add Start : Support for exporting scale inheritance (per-bone Inherit Scale property).
+    UE3_export_scale_inheritance: BoolProperty(
+        name="UE3 - Export Scale Inheritance",
+        description="If enabled, the per-bone Inherit Scale property is correctly exported "
+        "(AHiT supports 'Aligned', 'Average', 'None')",
+        default=DEF_EXPORT_SCALE_INHERITANCE,
+    )
+    # UnDrew Add End
     # UnDrew Add Start : Force Aligned scaling.
     UE3_force_aligned_scaling: BoolProperty(
         name="UE3 - Force Aligned Scaling",
@@ -1114,14 +1124,19 @@ def export_panel_armature(body: bpy.types.UILayout, operator: bpy.types.Operator
     body.prop(operator, "armature_nodetype")
     body.prop(operator, "use_armature_deform_only")
     body.prop(operator, "add_leaf_bones")
-    # UnDrew Add Start : Fix for Blender adding an extra root bone with the name of the Armature.
-    body.prop(operator, "UE3_dont_add_armature_bone")
-    # UnDrew Add End
-    # UnDrew Add Start : Force Aligned scaling.
-    body.prop(operator, "UE3_force_aligned_scaling")
-    # UnDrew Add End
-    # UnDrew Add Start : Matrix double precision.
-    row = body.row()
+    # UnDrew Add Start : Custom armature export settings.
+    sublayout = body.column()
+    sublayout.use_property_split = False  # These property names are pretty long, let's use all available space.
+    # Fix for Blender adding an extra root bone with the name of the Armature.
+    sublayout.prop(operator, "UE3_dont_add_armature_bone")
+    # Support for exporting scale inheritance (per-bone Inherit Scale property).
+    sublayout.prop(operator, "UE3_export_scale_inheritance")
+    # Force Aligned scaling.
+    row = sublayout.row()
+    row.enabled = operator.UE3_export_scale_inheritance
+    row.prop(operator, "UE3_force_aligned_scaling")
+    # Matrix double precision.
+    row = sublayout.row()
     row.prop(operator, "UE3_matrix_double_precision")
     row.label(text="", icon='ERROR')
     # UnDrew Add End

--- a/io_scene_fbx_patch_ahit/export_fbx_bin.py
+++ b/io_scene_fbx_patch_ahit/export_fbx_bin.py
@@ -3972,6 +3972,7 @@ def save_single(operator, scene, depsgraph, filepath="",
                 UE3_nla_modular_anim_support=True,
                 UE3_nla_only_animate_owner=True,
                 UE3_nla_force_export=False,
+                UE3_export_scale_inheritance=True,
                 UE3_force_aligned_scaling=True,
                 # UnDrew Add End
                 primary_bone_axis='Y',
@@ -4058,7 +4059,7 @@ def save_single(operator, scene, depsgraph, filepath="",
         UE3_dont_add_armature_bone, UE3_matrix_double_precision,
         UE3_rest_default_pose, UE3_remove_anim_object_prefix, UE3_nla_modular_anim_support,
         UE3_nla_only_animate_owner, UE3_nla_force_export,
-        UE3_force_aligned_scaling,
+        UE3_export_scale_inheritance, UE3_force_aligned_scaling,
         # UnDrew Add End
         # UnDrew Add Start : Not settings, but should be held here for performance reasons.
         UE3_global_matrix_no_scale,

--- a/io_scene_fbx_patch_ahit/fbx_utils.py
+++ b/io_scene_fbx_patch_ahit/fbx_utils.py
@@ -1861,7 +1861,7 @@ class ObjectWrapper(metaclass=MetaObjectWrapper):
         Blender's 'ALIGNED' is like 'NONE', but it also copies the parent's final scale with shear removed, and applies
         it to the current bone.
         """
-        if self.is_bone and self.bdata.parent:
+        if settings.UE3_export_scale_inheritance and self.is_bone and self.bdata.parent:
             inherit_scale = self.bdata.inherit_scale
             if inherit_scale in {'ALIGNED', 'NONE', 'AVERAGE'} or settings.UE3_force_aligned_scaling:
                 # ALIGNED/NONE/AVERAGE are interchangeable here (each one's effect can be replicated with another).
@@ -2174,7 +2174,7 @@ FBXExportSettings = namedtuple("FBXExportSettings", (
     "UE3_dont_add_armature_bone", "UE3_matrix_double_precision",
     "UE3_rest_default_pose", "UE3_remove_anim_object_prefix", "UE3_nla_modular_anim_support",
     "UE3_nla_only_animate_owner", "UE3_nla_force_export",
-    "UE3_force_aligned_scaling",
+    "UE3_export_scale_inheritance", "UE3_force_aligned_scaling",
     # UnDrew Add End
     # UnDrew Add Start : Not settings, but should be held here for performance reasons.
     "UE3_global_matrix_no_scale",


### PR DESCRIPTION
Adds a new setting to be consistent with the matching import setting.

Also moves armature export settings to a sublayout that removes some of the empty space, to avoid elipsis bonanzas.